### PR TITLE
JSON comparison system for integration tests

### DIFF
--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -351,6 +351,29 @@ class UpstreamIntegrationTests: XCTestCase {
           }
         """#
         
+        let multiline5 = #"""
+          {
+              "payload": [
+              {
+                "ttlSeconds" : 1800,
+                "scope" : "Target",
+                "hint" : "35"
+              },
+              {
+                "ttlSeconds" : 1800,
+                "scope" : "AAM",
+                "hint" : "9"
+              },
+              {
+                "ttlSeconds" : 1800,
+                "scope" : "EdgeNetwork",
+                "hint" : "or2"
+              }
+            ]
+          }
+        """#
+        
+        
         let result = try? JSONDecoder().decode(JSON.self, from: multiline3.data(using: .utf8)!)
         let result2 = try? JSONDecoder().decode(JSON.self, from: multiline4.data(using: .utf8)!)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
NOTE: this PR should be merged after branch: konductor-integration-test3

## Description

This PR implements JSON comparison for the Edge network extension + Edge network integration test workflow.

The proposed comparison system relies on a custom `enum JSON` with associated values that conforms to `Equatable` (technically for free since all the underlying associated values conform to `Equatable`! But default is overridden for reasons explained below) 

Conceptually the enum acts as a wrapper around a subset of the mysterious Swift `Any` type by carving out specific concrete types from the JSON spec that we want to convert to concrete Swift types and providing `Codable` and `Equatable` adherence.
* `Codable` gives us access to JSONDecoder/Encoder which means concrete Swift types
* `Equatable` gives us access to validation between JSON structures and compatibility with testing tools like `XCTAssertEqual` which rely on adherence to `Equatable`

### PROS
* Direct equivalence (`==`) between instances of `enum JSON` possible!
* Has strong type safety and validation since the enum acts like a type wrapper around actual associated types
* Works with `JSONDecoder` to easily decode JSON `Data` into concrete Swift types
* Flexible decoding strategy: All numbers could be interpreted as Double, or Int could be evaluated first if decimal vs non-decimal distinctions are important
* Easy copy-pastable transfer/updating of validation JSON string in test code which is directly decoded into the Swift typed validation structure. That is, in the test code you don't have to: 
    1. Figure out the flattened version of the key (if using flattened dictionary utility)
    2. Manually dig into the dictionaries, with all the [String: Any]? `guard`s/`if let`s, key presence, and value type validation
    3. Create a `Codable` struct with the entire validation structure already figured out, make sure it conforms to `Equatable` for easy comparison, and maintain it - also suffers from the mismatch discoverability problem (see below)

### CONS
All of the following cons are generally true of regular `[String: Any]` dictionaries; it is the nature of working with the `Any` type, which the `enum JSON` wraps: 
* Harder to access actual underlying values. They can be accessed using a getter function, but must effectively go through `Any?` typecasting (which is made a bit easier with generics)
* Dictionary traversal is as cumbersome as standard dictionaries

Since the primary use-case for the JSON comparison system is comparing entire JSON structures (ex: expected event payload == actual event payload), the ability to easily construct Equatable JSON instances that are directly comparable makes manual traversal and value extraction less necessary.

However, out of the box it is hard to get insight into where exactly the mismatch is, and with larger more complex JSON structures near impossible to pinpoint from the standard test failure output. Potential solutions:
1. Create a custom Equatable implementation that has logic to emit test failures where they occur specifically (this is implemented in this PR)
    * Additional support could be added to do an **array index**/**dictionary key** trace, since just value mismatch could also be hard to pinpoint (this is not yet implemented)
2. Manually copy-paste the mismatching JSON into a text diff tool (not desirable, especially since it defeats the purpose of automation)

Example of granular comparison mismatch being emitted from test run:
<img width="1100" alt="Screen Shot 2023-03-31 at 10 53 02 AM" src="https://user-images.githubusercontent.com/95260439/229194352-c6699e6e-ff2a-4f8a-9f5c-d0fae7b50039.png">
<img width="1089" alt="Screen Shot 2023-03-31 at 10 52 56 AM" src="https://user-images.githubusercontent.com/95260439/229194359-84df75b5-091b-4b1c-b14f-7b16dccadfa5.png">
<img width="1105" alt="Screen Shot 2023-03-31 at 10 52 49 AM" src="https://user-images.githubusercontent.com/95260439/229194364-a5e0c199-cb4e-42fd-817a-76c0d8a82634.png">


### Alternatives considered
#### 1. Comparison using conversion to NSDictionary/NSArray
For additional background see: https://stevenpcurtis.medium.com/compare-dictionaries-with-a-value-of-any-type-swift-3d3073f02f9e

Although it seems straightforward to use NSDictionary/NSArray and their `isEqual` comparisons, one important caveat is that if the JSON decode is done through `JSONSerialization`, Bool, (Int, and Double - number) types from the original JSON are all thrown into the NSNumber bucket. 
Then edge cases where even though the underlying types from the JSON mismatch, the comparison at the NSNumber level in the code may succeed and are not caught at the type level.
* Ex: NSNumber: Bool `true` is compared to NSNumber: Double `1` and returning true is possible, and we would definitely want to catch a type mismatch like this in our testing

#### 2. Dictionary flattening - as implemented in TestUtils.swift
This approach eliminates some potential (albeit extremely rare) edge cases from the dictionary flattening approach:
* It directly compares objects like Arrays and Dictionaries without having to use the `"isEmpty"` string
    * Eliminating the edge case where the same key in the comparison has "isEmpty" as its actual value

Input JSON:
```json
{
  "key1": []
}
```
Validation JSON:
```json
{
  "key1": "isEmpty"
}
```
* It does not modify any key values, eliminating another potential edge case where the compared JSON has a key at the top level that matches a flattened key

Input JSON:
```json
{
  "key1": {
    "nested2": "value2"
  }
}
```
Validation JSON:
```json
{
  "key1.nested2": "value2"
}
```


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
